### PR TITLE
Handle dropped players, fix empty divsions

### DIFF
--- a/pages/standings/index.tsx
+++ b/pages/standings/index.tsx
@@ -151,6 +151,7 @@ export const getStaticProps: GetStaticProps = async context => {
     const base = getBase();
     await base(getBaseName('players'))
         .select({
+            filterByFormula: `{dropped} != TRUE()`,
             sort: [{ field: 'Elo', direction: 'desc' }],
         })
         .eachPage((records, fetchNextPage) => {
@@ -180,8 +181,10 @@ export const getStaticProps: GetStaticProps = async context => {
     const filteredMatches = matches.filter(
         match =>
             match.week.toLowerCase().indexOf('playoff') == -1 &&
-            match.week.toLowerCase().indexOf('showcase') == -1
+            match.week.toLowerCase().indexOf('showcase') == -1 &&
+            match.matchTime > 1664521200 // This is a hack to filter out the first half matches from the standings, gotta come up with a better system in the future :(
     );
+    console.log(filteredMatches);
     const divisionMapping = splitIntoDivisions(filteredMatches, sortedPlayers);
     const standingsArray = [];
     if (Array.from(divisionMapping.keys()).length > 0) {

--- a/types/convertAirtableDataToPlayerData.ts
+++ b/types/convertAirtableDataToPlayerData.ts
@@ -7,7 +7,7 @@ export default function convertAirtableDataToPlayerData(record: Record<FieldSet>
         primaryColor: (record.get('Primary') as string)?.toLowerCase() as any,
         secondaryColor: (record.get('Secondary') as string)?.toLowerCase() as any,
         country: (record.get('Country') as string)?.toLowerCase(),
-        division: record.get('Division') as string,
+        division: (record.get('Division') as string) ?? '',
         twitchName: record.get('Twitch') as string,
         pronouns: (record.get('Pronouns') as string) ?? '',
         elo: (record.get('Elo') as number) ?? -1,


### PR DESCRIPTION
Fix the fact we have random empty divisions by filtering out matches prior to a specific date (it's a dirty hack, but whatever).
Also handle dropped players so that they don't show up in the standings.